### PR TITLE
fix schema syncing

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ The collection name will be automatically derived from the class name (pluralize
 - Complex queries should use the PocketBase client directly
 - Relationship handling is limited to single relations
 - Indexes must be created manually
-- Schemas need to be updated manually until [this issue](https://github.com/vaphes/pocketbase/issues/117) is resolved
+- Schema syncing currently relies on a fork until https://github.com/vaphes/pocketbase/pull/120 is merged
 
 ## Contributing
 

--- a/justfile
+++ b/justfile
@@ -8,7 +8,7 @@ publish: test clear build
     uv publish
 
 test:
-    uv run pytest tests/
+    uv run pytest -xvs tests/
 
 format:
     uvx ruff format .

--- a/pocketbase_orm.py
+++ b/pocketbase_orm.py
@@ -8,7 +8,7 @@ from pocketbase import PocketBase
 from pocketbase.client import FileUpload
 from pydantic import AnyUrl, BaseModel, EmailStr, Field
 
-__version__ = "0.14.1"
+__version__ = "0.15.0"
 
 logger = logging.getLogger(__name__)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ requires = ["flit_core >=3.2,<4"]
 
 [project]
 dependencies = [
-  "pocketbase>=0.14.0",
+  "pocketbase>=0.15.0",
   "pydantic[email]>=2.10.6",
 ]
 description = "Add your description here"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,3 +18,7 @@ dynamic = ["version"]
 dev = [
     "pytest>=8.3.4",
 ]
+
+# TODO: Remove this once https://github.com/vaphes/pocketbase/pull/120 is merged
+[tool.uv.sources]
+pocketbase = { git = "https://github.com/knowsuchagency/pocketbase", branch = "update-collection-field" }

--- a/uv.lock
+++ b/uv.lock
@@ -139,19 +139,19 @@ wheels = [
 
 [[package]]
 name = "pocketbase"
-version = "0.14.0"
+version = "0.15.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ca/8c/589e30935a8c5618ec2a541a14cfd1fafb96c97a94cbe984a46d5664aff7/pocketbase-0.14.0.tar.gz", hash = "sha256:154c704964bfaabf17f2c3c7c4ad0869a30e62af9e7208f63f9bb6748805e67b", size = 17953 }
+sdist = { url = "https://files.pythonhosted.org/packages/3d/4e/3397e1021325f026458b7a7cffa2353b6827f05db9d6054b65318f4a70d3/pocketbase-0.15.0.tar.gz", hash = "sha256:dd3a8ce20da09a83f5e0a5b55fc72d40874f562c15d886d5ec5a072e346d3fd9", size = 16825 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/62/10/a1e52639ae82088dd5cba50eb6fcc2e0e8fd0add859a54785b6c16f2a7b9/pocketbase-0.14.0-py3-none-any.whl", hash = "sha256:3077f21cd24c5543301e28058bbcb93d2ea5048872cac1669ab4497faab784a8", size = 27773 },
+    { url = "https://files.pythonhosted.org/packages/8f/ac/880b1290e0378c781941d071070dac16871212d2f8b2222daadacd28f59e/pocketbase-0.15.0-py3-none-any.whl", hash = "sha256:f5a77e73a661859353cf2f51422ee54b77374c21ea1781cf7e0baffb6e110cc7", size = 28024 },
 ]
 
 [[package]]
 name = "pocketbase-orm"
-version = "0.3.1"
+version = "0.14.1"
 source = { editable = "." }
 dependencies = [
     { name = "pocketbase" },
@@ -165,7 +165,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "pocketbase", specifier = ">=0.14.0" },
+    { name = "pocketbase", specifier = ">=0.15.0" },
     { name = "pydantic", extras = ["email"], specifier = ">=2.10.6" },
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -140,18 +140,14 @@ wheels = [
 [[package]]
 name = "pocketbase"
 version = "0.15.0"
-source = { registry = "https://pypi.org/simple" }
+source = { git = "https://github.com/knowsuchagency/pocketbase?branch=update-collection-field#2f1bc1b646c98eed5ea35362f9fa3a03538cd5b2" }
 dependencies = [
     { name = "httpx" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/3d/4e/3397e1021325f026458b7a7cffa2353b6827f05db9d6054b65318f4a70d3/pocketbase-0.15.0.tar.gz", hash = "sha256:dd3a8ce20da09a83f5e0a5b55fc72d40874f562c15d886d5ec5a072e346d3fd9", size = 16825 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/8f/ac/880b1290e0378c781941d071070dac16871212d2f8b2222daadacd28f59e/pocketbase-0.15.0-py3-none-any.whl", hash = "sha256:f5a77e73a661859353cf2f51422ee54b77374c21ea1781cf7e0baffb6e110cc7", size = 28024 },
 ]
 
 [[package]]
 name = "pocketbase-orm"
-version = "0.14.1"
+version = "0.15.0"
 source = { editable = "." }
 dependencies = [
     { name = "pocketbase" },
@@ -165,7 +161,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "pocketbase", specifier = ">=0.15.0" },
+    { name = "pocketbase", git = "https://github.com/knowsuchagency/pocketbase?branch=update-collection-field" },
     { name = "pydantic", extras = ["email"], specifier = ">=2.10.6" },
 ]
 
@@ -246,7 +242,7 @@ wheels = [
 
 [[package]]
 name = "pytest"
-version = "8.3.4"
+version = "8.3.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
@@ -254,9 +250,9 @@ dependencies = [
     { name = "packaging" },
     { name = "pluggy" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/05/35/30e0d83068951d90a01852cb1cef56e5d8a09d20c7f511634cc2f7e0372a/pytest-8.3.4.tar.gz", hash = "sha256:965370d062bce11e73868e0335abac31b4d3de0e82f4007408d242b4f8610761", size = 1445919 }
+sdist = { url = "https://files.pythonhosted.org/packages/ae/3c/c9d525a414d506893f0cd8a8d0de7706446213181570cdbd766691164e40/pytest-8.3.5.tar.gz", hash = "sha256:f4efe70cc14e511565ac476b57c279e12a855b11f48f212af1080ef2263d3845", size = 1450891 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/11/92/76a1c94d3afee238333bc0a42b82935dd8f9cf8ce9e336ff87ee14d9e1cf/pytest-8.3.4-py3-none-any.whl", hash = "sha256:50e16d954148559c9a74109af1eaf0c945ba2d8f30f0a3d3335edde19788b6f6", size = 343083 },
+    { url = "https://files.pythonhosted.org/packages/30/3d/64ad57c803f1fa1e963a7946b6e0fea4a70df53c1a7fed304586539c2bac/pytest-8.3.5-py3-none-any.whl", hash = "sha256:c69214aa47deac29fad6c2a4f590b9c4a9fdb16a403176fe154b79c0b4d4d820", size = 343634 },
 ]
 
 [[package]]


### PR DESCRIPTION
- Change schema references to fields in PBModel for consistency
- Update pytest command in justfile for verbose output
- Adjust README to reflect schema syncing reliance on a fork
- Bump pytest version to 8.3.5 in uv.lock
- Enhance tests for enum field handling in ModelWithEnum